### PR TITLE
Use for default tolerance stripe.Webhook.DEFAULT_TOLERANCE (instead d…

### DIFF
--- a/djstripe/models/webhooks.py
+++ b/djstripe/models/webhooks.py
@@ -83,7 +83,7 @@ class WebhookEndpoint(StripeModel):
         )
 
         self.djstripe_uuid = data.get("metadata", {}).get("djstripe_uuid")
-        self.tolerance = data.get("tolerance", djstripe_settings.WEBHOOK_TOLERANCE)
+        self.tolerance = data.get("tolerance", stripe.Webhook.DEFAULT_TOLERANCE)
 
 
 def _get_version():


### PR DESCRIPTION
…jstripe_settings.WEBHOOK_TOLERANCE, since it was removed)

<!--

Thank you for your pull request!

Please adhere to the following guidelines:

- Clear, single-purpose, atomic commits with a short summary and a descriptive body.
- Make sure your code is tested, especially if it fixes bugs or introduces complexity.
- Document important changes in the changelog (Most recent file in docs/history/ folder)

Much appreciated!

-->
